### PR TITLE
AutoKey feature

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,10 +4,17 @@ const truthy = x => x;
 
 export default theme => (key, ...names) => {
   const styles = names
-    .map(name => theme[name])
+    .map(name => {
+      return theme[name]
+    })
     .filter(truthy);
 
   return typeof styles[0] === 'string' ?
     { key, className: styles.join(' ') } :
     { key, style: assign({}, ...styles) };
 };
+
+export const autokey = (fnc) => {
+  let autoKey = 1
+  return (...names) => fnc(autoKey++, ...names)
+}

--- a/src/index.js
+++ b/src/index.js
@@ -4,9 +4,7 @@ const truthy = x => x;
 
 export default theme => (key, ...names) => {
   const styles = names
-    .map(name => {
-      return theme[name]
-    })
+    .map(name => theme[name])
     .filter(truthy);
 
   return typeof styles[0] === 'string' ?

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,5 @@
-import themeable from '../src';
+import themeable, { autokey } from '../src';
 import { expect } from 'chai';
-
 describe('className', () => {
   const classes = { foo: 'aaa', bar: 'bbb' };
   const classTheme = themeable(classes);
@@ -74,6 +73,62 @@ describe('style', () => {
         style: {
           color: 'red',
           fontSize: '16px'
+        }
+      });
+  });
+
+});
+
+describe('autokey', () => {
+  const classes = { foo: 'aaa', bar: 'bbb' };
+  const styles = {
+    foo: {
+      color: 'red',
+      fontSize: '16px'
+    },
+    bar: {
+      color: 'blue',
+      fontWeight: 'bold'
+    }
+  };
+  const classTheme = autokey(themeable(classes));
+  const styleTheme = autokey(themeable(styles));
+
+  it('should return a single class', () => {
+    expect(classTheme('foo'))
+      .to.deep.equal({
+        key: 1,
+        className: classes.foo
+      });
+  });
+
+  it('should return multiple classes', () => {
+    expect(classTheme('foo', 'bar'))
+      .to.deep.equal({
+        key: 2,
+        className: `${classes.foo} ${classes.bar}`
+      });
+  });
+
+  it('should return a single style', () => {
+    expect(styleTheme('foo'))
+      .to.deep.equal({
+        key: 1,
+        style: {
+          color: 'red',
+          fontSize: '16px'
+        }
+      });
+  });
+
+  it('should return multiple styles merged', () => {
+    expect(styleTheme('foo', 'bar'))
+      .to.deep.equal({
+        key: 2,
+        style: {
+          fontSize: '16px',
+          color: 'blue',
+          fontWeight: 'bold'
         }
       });
   });


### PR DESCRIPTION
While `key` is only required by Radium it would be nice to use `theme` function without it. 
I wrote simple wrapper for `theme` function to address this feature. So:

```
import themeable, { autokey } from '../src';
const theme = autokey(themeable(classes))
theme('foo', 'bar')
```

Thank you for your work!
